### PR TITLE
change waffle config key

### DIFF
--- a/waffle-config.json
+++ b/waffle-config.json
@@ -1,5 +1,5 @@
 {
-	"sourcesPath": "./contracts",
-	"targetPath": "./build",
-	"npmPath": "./node_modules"
+	"sourceDirectory": "./contracts",
+	"outputDirectory": "./build",
+	"nodeModulesDirectory": "./node_modules"
 }


### PR DESCRIPTION
The key for waffle-config has changed since version 2.4.0.



https://ethereum-waffle.readthedocs.io/_/downloads/en/stable/pdf/

```
3.9.2 Migration from Waffle 2.3.0 to Waffle 2.4.0
Renamed configuration options
We renamed configuration options to compile contracts:
• sourcesPath - renamed to sourceDirectory
• targetPath - renamed to outputDirectory
• npmPath - renamed to nodeModulesDirectory
```